### PR TITLE
초기 엔티티 구현

### DIFF
--- a/src/main/java/kr/wordme/model/entity/DailyQuizDistractor.java
+++ b/src/main/java/kr/wordme/model/entity/DailyQuizDistractor.java
@@ -1,0 +1,37 @@
+package kr.wordme.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "daily_quiz_distractor")
+@NoArgsConstructor
+@Getter
+public class DailyQuizDistractor {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "daily_quiz_word_id")
+	private DailyQuizWord dailyQuizWord;
+
+	@Column(name = "distractor_text")
+	private String distractorText;
+
+	@Column(name = "distractor_number")
+	private Integer distractorNumber;
+
+	@Column(name = "answer_sign", columnDefinition = "TINYINT(1)", nullable = false)
+	private Boolean answerSign;
+}

--- a/src/main/java/kr/wordme/model/entity/DailyQuizWord.java
+++ b/src/main/java/kr/wordme/model/entity/DailyQuizWord.java
@@ -1,0 +1,40 @@
+package kr.wordme.model.entity;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "daily_quiz_word")
+@NoArgsConstructor
+@Getter
+public class DailyQuizWord {
+
+	@Id
+	private UUID id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "word_id")
+	private Word word;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "word_category_id")
+	private WordCategory wordCategory;
+
+	@Column(name = "quiz_date")
+	private Timestamp quizDate;
+
+	@OneToMany(mappedBy = "dailyQuizWord", fetch = FetchType.LAZY)
+	private List<DailyQuizDistractor> dailyQuizDistractors;
+}

--- a/src/main/java/kr/wordme/model/entity/DailyQuizWord.java
+++ b/src/main/java/kr/wordme/model/entity/DailyQuizWord.java
@@ -4,6 +4,7 @@ import java.sql.Timestamp;
 import java.util.List;
 import java.util.UUID;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -35,6 +36,11 @@ public class DailyQuizWord {
 	@Column(name = "quiz_date")
 	private Timestamp quizDate;
 
-	@OneToMany(mappedBy = "dailyQuizWord", fetch = FetchType.LAZY)
+	@OneToMany(
+		mappedBy = "dailyQuizWord",
+		fetch = FetchType.LAZY,
+		cascade = {CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.MERGE},
+		orphanRemoval = true
+	)
 	private List<DailyQuizDistractor> dailyQuizDistractors;
 }

--- a/src/main/java/kr/wordme/model/entity/Member.java
+++ b/src/main/java/kr/wordme/model/entity/Member.java
@@ -34,7 +34,7 @@ public class Member {
 	@CreationTimestamp
 	private Timestamp createdAt;
 
-	@Column(name = "is_deleted", nullable = false)
+	@Column(name = "is_deleted", columnDefinition = "TINYINT(1)", nullable = false)
 	private Boolean isDeleted;
 
 }

--- a/src/main/java/kr/wordme/model/entity/Member.java
+++ b/src/main/java/kr/wordme/model/entity/Member.java
@@ -37,4 +37,10 @@ public class Member {
 	@Column(name = "is_deleted", columnDefinition = "TINYINT(1)", nullable = false)
 	private Boolean isDeleted;
 
+	@Column(name = "is_daily_quiz_subscribed", columnDefinition = "TINYINT(1)")
+	private Boolean isDailyQuizSubscribed;
+
+	@Column(name = "daily_quiz_subscribed_at")
+	private Timestamp dailyQuizSubscribedAt;
+
 }

--- a/src/main/java/kr/wordme/model/entity/Member.java
+++ b/src/main/java/kr/wordme/model/entity/Member.java
@@ -1,0 +1,40 @@
+package kr.wordme.model.entity;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member")
+@NoArgsConstructor
+@Getter
+public class Member {
+
+	@Id
+	private UUID id;
+
+	@Column(name = "email", nullable = false)
+	private String email;
+
+	@Column(name = "nickname", nullable = false)
+	private String nickname;
+
+	@Column(name = "password")
+	private String password;
+
+	@Column(name = "created_at", updatable = false)
+	@CreationTimestamp
+	private Timestamp createdAt;
+
+	@Column(name = "is_deleted", nullable = false)
+	private Boolean isDeleted;
+
+}

--- a/src/main/java/kr/wordme/model/entity/MemberDailyQuizRecord.java
+++ b/src/main/java/kr/wordme/model/entity/MemberDailyQuizRecord.java
@@ -1,0 +1,44 @@
+package kr.wordme.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+	name = "member_daily_quiz_record",
+	uniqueConstraints = {
+		@UniqueConstraint(columnNames = {"member_id", "daily_quiz_id"})
+	}
+)
+@NoArgsConstructor
+@Getter
+public class MemberDailyQuizRecord {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private long id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "daily_quiz_id")
+	private DailyQuizWord dailyQuizWord;
+
+	@Column(name = "submitted_answer")
+	private Integer submittedAnswer;
+
+	@Column(name = "correct_sign", columnDefinition = "TINYINT(1)")
+	private Boolean correctSign;
+}

--- a/src/main/java/kr/wordme/model/entity/MemberDailyQuizRecord.java
+++ b/src/main/java/kr/wordme/model/entity/MemberDailyQuizRecord.java
@@ -39,6 +39,6 @@ public class MemberDailyQuizRecord {
 	@Column(name = "submitted_answer")
 	private Integer submittedAnswer;
 
-	@Column(name = "correct_sign", columnDefinition = "TINYINT(1)")
+	@Column(name = "correct_sign", columnDefinition = "TINYINT(1)", nullable = false)
 	private Boolean correctSign;
 }

--- a/src/main/java/kr/wordme/model/entity/MemberMockExamQuestionRecord.java
+++ b/src/main/java/kr/wordme/model/entity/MemberMockExamQuestionRecord.java
@@ -1,0 +1,38 @@
+package kr.wordme.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_mock_exam_question_record")
+@NoArgsConstructor
+@Getter
+public class MemberMockExamQuestionRecord {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "member_mock_exam_record_id")
+	private MemberMockExamRecord memberMockExamRecord;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "mock_exam_question_id")
+	private MockExamQuestion mockExamQuestion;
+
+	@Column(name = "submitted_answer")
+	private Integer submittedAnswer;
+
+	@Column(name = "correct_sign", columnDefinition = "TINYINT(1)")
+	private Boolean correctSign;
+}

--- a/src/main/java/kr/wordme/model/entity/MemberMockExamQuestionRecord.java
+++ b/src/main/java/kr/wordme/model/entity/MemberMockExamQuestionRecord.java
@@ -33,6 +33,6 @@ public class MemberMockExamQuestionRecord {
 	@Column(name = "submitted_answer")
 	private Integer submittedAnswer;
 
-	@Column(name = "correct_sign", columnDefinition = "TINYINT(1)")
+	@Column(name = "correct_sign", columnDefinition = "TINYINT(1)", nullable = false)
 	private Boolean correctSign;
 }

--- a/src/main/java/kr/wordme/model/entity/MemberMockExamRecord.java
+++ b/src/main/java/kr/wordme/model/entity/MemberMockExamRecord.java
@@ -1,14 +1,17 @@
 package kr.wordme.model.entity;
 
 import java.sql.Timestamp;
+import java.util.List;
 import java.util.UUID;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -38,4 +41,12 @@ public class MemberMockExamRecord {
 
 	@Column(name = "end_time")
 	private Timestamp endTime;
+
+	@OneToMany(
+		mappedBy = "memberMockExamRecord",
+		fetch = FetchType.LAZY,
+		cascade = {CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.MERGE},
+		orphanRemoval = true
+	)
+	private List<MemberMockExamQuestionRecord> memberMockExamQuestionRecords;
 }

--- a/src/main/java/kr/wordme/model/entity/MemberMockExamRecord.java
+++ b/src/main/java/kr/wordme/model/entity/MemberMockExamRecord.java
@@ -1,0 +1,41 @@
+package kr.wordme.model.entity;
+
+import java.sql.Timestamp;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "member_mock_exam_record")
+@NoArgsConstructor
+@Getter
+public class MemberMockExamRecord {
+
+	@Id
+	private UUID id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "mock_exam_id")
+	private MockExam mockExam;
+
+	@Column(name = "score")
+	private Integer score;
+
+	@Column(name = "start_time")
+	private Timestamp startTime;
+
+	@Column(name = "end_time")
+	private Timestamp endTime;
+}

--- a/src/main/java/kr/wordme/model/entity/MockExam.java
+++ b/src/main/java/kr/wordme/model/entity/MockExam.java
@@ -1,0 +1,44 @@
+package kr.wordme.model.entity;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "mock_exam")
+@NoArgsConstructor
+@Getter
+public class MockExam {
+
+	@Id
+	private UUID id;
+
+	@Column(name = "title")
+	private String title;
+
+	@Column(name = "created_at", updatable = false)
+	@CreationTimestamp
+	private Timestamp createdAt;
+
+	@Column(name = "modified_at")
+	@UpdateTimestamp
+	private Timestamp modifiedAt;
+
+	@Column(name = "time_limit_in_minutes")
+	private Integer timeLimitInMinutes;
+
+	@OneToMany(mappedBy = "mockExam", fetch = FetchType.LAZY)
+	private List<MockExamQuestion> questions;
+}

--- a/src/main/java/kr/wordme/model/entity/MockExam.java
+++ b/src/main/java/kr/wordme/model/entity/MockExam.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -39,6 +40,11 @@ public class MockExam {
 	@Column(name = "time_limit_in_minutes")
 	private Integer timeLimitInMinutes;
 
-	@OneToMany(mappedBy = "mockExam", fetch = FetchType.LAZY)
+	@OneToMany(
+		mappedBy = "mockExam",
+		fetch = FetchType.LAZY,
+		cascade = {CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.MERGE},
+		orphanRemoval = true
+	)
 	private List<MockExamQuestion> questions;
 }

--- a/src/main/java/kr/wordme/model/entity/MockExamDistractor.java
+++ b/src/main/java/kr/wordme/model/entity/MockExamDistractor.java
@@ -1,0 +1,37 @@
+package kr.wordme.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "mock_exam_distractor")
+@NoArgsConstructor
+@Getter
+public class MockExamDistractor {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "mock_exam_question_id")
+	private MockExamQuestion mockExamQuestion;
+
+	@Column(name = "distractor_text", columnDefinition = "TEXT")
+	private String distractorText;
+
+	@Column(name = "distractor_number")
+	private int distractorNumber;
+
+	@Column(name = "answer_sign", columnDefinition = "TINYINT(1)")
+	private Boolean answerSign;
+}

--- a/src/main/java/kr/wordme/model/entity/MockExamQuestion.java
+++ b/src/main/java/kr/wordme/model/entity/MockExamQuestion.java
@@ -1,0 +1,35 @@
+package kr.wordme.model.entity;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "mock_exam_question")
+@NoArgsConstructor
+@Getter
+public class MockExamQuestion {
+
+	@Id
+	private UUID id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "mock_exam_id")
+	private MockExam mockExam;
+
+	@Column(name = "question_text", columnDefinition = "TEXT")
+	private String questionText;
+
+	@OneToMany(mappedBy = "mockExamQuestion", fetch = FetchType.LAZY)
+	private List<MockExamDistractor> distractors;
+}

--- a/src/main/java/kr/wordme/model/entity/MockExamQuestion.java
+++ b/src/main/java/kr/wordme/model/entity/MockExamQuestion.java
@@ -3,6 +3,7 @@ package kr.wordme.model.entity;
 import java.util.List;
 import java.util.UUID;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -30,6 +31,11 @@ public class MockExamQuestion {
 	@Column(name = "question_text", columnDefinition = "TEXT")
 	private String questionText;
 
-	@OneToMany(mappedBy = "mockExamQuestion", fetch = FetchType.LAZY)
+	@OneToMany(
+		mappedBy = "mockExamQuestion",
+		fetch = FetchType.LAZY,
+		cascade = {CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.MERGE},
+		orphanRemoval = true
+	)
 	private List<MockExamDistractor> distractors;
 }

--- a/src/main/java/kr/wordme/model/entity/TestEntity.java
+++ b/src/main/java/kr/wordme/model/entity/TestEntity.java
@@ -1,4 +1,0 @@
-package kr.wordme.model.entity;
-
-public class TestEntity {
-}

--- a/src/main/java/kr/wordme/model/entity/Word.java
+++ b/src/main/java/kr/wordme/model/entity/Word.java
@@ -1,0 +1,26 @@
+package kr.wordme.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "word")
+@NoArgsConstructor
+@Getter
+public class Word {
+
+	@Id
+	@Column(name = "word_spelling")
+	private String wordSpelling;
+
+	@Column(name = "pronunciation_file_name", nullable = false)
+	private String pronunciationFileName;
+
+	@Column(name = "pronunciation_url", nullable = false)
+	private String pronunciationUrl;
+
+}

--- a/src/main/java/kr/wordme/model/entity/WordCategory.java
+++ b/src/main/java/kr/wordme/model/entity/WordCategory.java
@@ -1,0 +1,31 @@
+package kr.wordme.model.entity;
+
+import java.util.List;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "word_category")
+@NoArgsConstructor
+@Getter
+public class WordCategory {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "category_name")
+	private String categoryName;
+
+	@OneToMany(mappedBy = "wordCategory", fetch = FetchType.LAZY)
+	private List<WordNote> wordNotes;
+}

--- a/src/main/java/kr/wordme/model/entity/WordNote.java
+++ b/src/main/java/kr/wordme/model/entity/WordNote.java
@@ -7,11 +7,10 @@ import java.util.UUID;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
@@ -59,6 +58,11 @@ public class WordNote {
 	@UpdateTimestamp
 	private Timestamp modifiedAt;
 
-	@OneToMany(mappedBy = "wordNote", fetch = FetchType.LAZY)
+	@OneToMany(
+		mappedBy = "wordNote",
+		fetch = FetchType.LAZY,
+		cascade = {CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.MERGE},
+		orphanRemoval = true
+	)
 	private List<WordNoteWord> wordNoteWords;
 }

--- a/src/main/java/kr/wordme/model/entity/WordNote.java
+++ b/src/main/java/kr/wordme/model/entity/WordNote.java
@@ -1,0 +1,64 @@
+package kr.wordme.model.entity;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "word_note")
+@NoArgsConstructor
+@Getter
+public class WordNote {
+
+	@Id
+	private UUID id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "initial_creator_id")
+	private Member initialCreator;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "owner_id")
+	private Member owner;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "word_category_id")
+	private WordCategory wordCategory;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "forked_word_note_id")
+	private WordNote forkedWordNote;
+
+	@Column(name = "title")
+	private String title;
+
+	@Column(name = "delete_sign")
+	private Boolean deleteSign;
+
+	@Column(name = "created_at", updatable = false)
+	@CreationTimestamp
+	private Timestamp createdAt;
+
+	@Column(name = "modified_at")
+	@UpdateTimestamp
+	private Timestamp modifiedAt;
+
+	@OneToMany(mappedBy = "wordNote", fetch = FetchType.LAZY)
+	private List<WordNoteWord> wordNoteWords;
+}

--- a/src/main/java/kr/wordme/model/entity/WordNoteWord.java
+++ b/src/main/java/kr/wordme/model/entity/WordNoteWord.java
@@ -1,0 +1,43 @@
+package kr.wordme.model.entity;
+
+import java.sql.Timestamp;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.CreationTimestamp;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "word_note_word")
+@NoArgsConstructor
+@Getter
+public class WordNoteWord {
+
+	@Id
+	private UUID id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "word_note_id")
+	private WordNote wordNote;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "word_id")
+	private Word word;
+
+	@Column(name = "created_at", updatable = false)
+	@CreationTimestamp
+	private Timestamp createdAt;
+
+	@OneToMany(mappedBy = "wordNoteWord", fetch = FetchType.LAZY)
+	private List<WordNoteWordMeaning> wordNoteWordMeanings;
+}

--- a/src/main/java/kr/wordme/model/entity/WordNoteWord.java
+++ b/src/main/java/kr/wordme/model/entity/WordNoteWord.java
@@ -1,11 +1,12 @@
 package kr.wordme.model.entity;
 
 import java.sql.Timestamp;
-import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import org.hibernate.annotations.CreationTimestamp;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -38,6 +39,19 @@ public class WordNoteWord {
 	@CreationTimestamp
 	private Timestamp createdAt;
 
-	@OneToMany(mappedBy = "wordNoteWord", fetch = FetchType.LAZY)
-	private List<WordNoteWordMeaning> wordNoteWordMeanings;
+	@OneToMany(
+		mappedBy = "wordNoteWord",
+		fetch = FetchType.LAZY,
+		cascade = {CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.MERGE},
+		orphanRemoval = true
+	)
+	private Set<WordNoteWordMeaning> wordNoteWordMeanings;
+
+	@OneToMany(
+		mappedBy = "wordNoteWord",
+		fetch = FetchType.LAZY,
+		cascade = {CascadeType.PERSIST, CascadeType.REMOVE, CascadeType.MERGE},
+		orphanRemoval = true
+	)
+	private Set<WordNoteWordTag> wordNoteWordTags;
 }

--- a/src/main/java/kr/wordme/model/entity/WordNoteWordMeaning.java
+++ b/src/main/java/kr/wordme/model/entity/WordNoteWordMeaning.java
@@ -1,0 +1,31 @@
+package kr.wordme.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "word_note_word_meaning")
+@NoArgsConstructor
+@Getter
+public class WordNoteWordMeaning {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "word_note_word_id")
+	private WordNoteWord wordNoteWord;
+
+	@Column(name = "meaning", nullable = true)
+	private String meaning;
+}

--- a/src/main/java/kr/wordme/model/entity/WordNoteWordMeaning.java
+++ b/src/main/java/kr/wordme/model/entity/WordNoteWordMeaning.java
@@ -26,6 +26,6 @@ public class WordNoteWordMeaning {
 	@JoinColumn(name = "word_note_word_id")
 	private WordNoteWord wordNoteWord;
 
-	@Column(name = "meaning", nullable = true)
+	@Column(name = "meaning")
 	private String meaning;
 }

--- a/src/main/java/kr/wordme/model/entity/WordNoteWordTag.java
+++ b/src/main/java/kr/wordme/model/entity/WordNoteWordTag.java
@@ -1,0 +1,31 @@
+package kr.wordme.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "word_note_word_tag")
+@NoArgsConstructor
+@Getter
+public class WordNoteWordTag {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.EAGER)
+	@JoinColumn(name = "word_note_word_id")
+	private WordNoteWord wordNoteWord;
+
+	@Column(name = "tag_name")
+	private String tagName;
+}


### PR DESCRIPTION
## 개요
초기 엔티티 구현

## 상세 내용
1. 회원 엔티티 구현(WordMe-1)
2. 단어장 관련 엔티티 구현(WordMe-4)
3. 일일 영단어 문제 관련 엔티티 구현(WordMe-5)
4. 모의고사 관련 엔티티 구현(WordMe-7)
5. test entity 제거
6. 엔티티 설계 관련 고민
   + 단어 카테고리를 단어장과 일일 퀴즈에서 공유할지, 따로 관리할지 고민됩니다.
   + 속성의 nullable 제약 조건에 대한 피드백을 남겨주셨으면 좋겠습니다.

## 유형

- [x]  새로운 기능 추가
- [ ]  버그 수정
- [ ]  코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ]  코드 리팩토링
- [ ]  주석 추가 및 수정
- [ ]  문서 수정
- [ ]  테스트 추가, 테스트 리팩토링
- [ ]  빌드 부분 혹은 패키지 매니저 수정
- [ ]  파일 혹은 폴더명 수정
- [x]  파일 혹은 폴더 삭제
- [ ]  디자인

## Checklist
- [x] 커밋 메세지를 컨벤션에 맞게 작성하셨나요?
- [ ] 작업 범위에 대해서 테스트를 작성하셨나요?
- [x] 무엇을 변경했는지 충분히 설명하고 있나요?
